### PR TITLE
Separate wkhtmltopdf from main playbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,20 @@
 # Ansible Rails Server Setup
 
+## Usage
+
+You can run this Ansible Playbook using the following command and completing the parts specific to your setup.
+This also includes setting users and host groups with site.yml as these may not be the same as you have.
+
+```
+ansible-playbook site.yml -i << your inventory file >> -l group
+```
+
+You also have the ability to skip some parts of the Playbook from running
+
+```
+ansible-playbook site.yml -i << your inventory file >> -l group --skip-tags "wkhtmltopdf"
+```
+
 ## RVM role
 This playbook uses the rvm1-ruby role, you will need to install this using Ansible Galaxy
 ```

--- a/roles/web/tasks/production_requirements.yml
+++ b/roles/web/tasks/production_requirements.yml
@@ -7,11 +7,5 @@
     - imagemagick
     - git-core
 
-- name: Create the wkhtmltopdf app directory.
-  file: state=directory path=/opt/wkhtmltopdf
 
-- name: Fetching wkhtmltopdf archive
-  get_url: url=http://downloads.sourceforge.net/wkhtmltopdf/wkhtmltox-0.12.2.1_linux-trusty-amd64.deb dest=/opt/wkhtmltopdf/wkhtmltox-0.12.2.1_linux-trusty-amd64.deb validate_certs=no
-
-- name: Install wkthtmltopdf package
-  apt: deb=/opt/wkhtmltopdf/wkhtmltox-0.12.2.1_linux-trusty-amd64.deb state=installed
+- include: wkhtmltopdf.yml tags: wkhtmltopdf

--- a/roles/web/tasks/wkhtmltopdf.yml
+++ b/roles/web/tasks/wkhtmltopdf.yml
@@ -1,0 +1,8 @@
+- name: Create the wkhtmltopdf app directory.
+  file: state=directory path=/opt/wkhtmltopdf
+
+- name: Fetching wkhtmltopdf archive
+  get_url: url=http://downloads.sourceforge.net/wkhtmltopdf/wkhtmltox-0.12.2.1_linux-trusty-amd64.deb dest=/opt/wkhtmltopdf/wkhtmltox-0.12.2.1_linux-trusty-amd64.deb validate_certs=no
+
+- name: Install wkthtmltopdf package
+  apt: deb=/opt/wkhtmltopdf/wkhtmltox-0.12.2.1_linux-trusty-amd64.deb state=installed


### PR DESCRIPTION
WkhtmltoPDF is not always guaranteed as a production requirement. This fixes #3.
