### PR TITLE
Add reboot if required

### DIFF
--- a/roles/reboot-if-required/defaults/main.yml
+++ b/roles/reboot-if-required/defaults/main.yml
@@ -1,0 +1,6 @@
+---
+ip_to_probe: "{{inventory_hostname}}"
+port_to_probe: 22
+delay_before_probe: 10
+probe_timeout: 70
+force_reboot: False

--- a/roles/reboot-if-required/tasks/main.yml
+++ b/roles/reboot-if-required/tasks/main.yml
@@ -1,0 +1,14 @@
+# taken from https://github.com/amarao/ansible-reboot-if-needed-for-upgrade
+# copied to make it easier to cusomise Slack notifications
+
+---
+  - name: Rebooting server if pending
+    shell: reboot removes=/var/run/reboot-required
+    register: reboot
+
+  - name: Waiting until boot is done
+    wait_for: host={{ip_to_probe}} port={{port_to_probe}} delay={{delay_before_probe}} timeout={{probe_timeout}}
+    connection: local
+    sudo: false
+    when: reboot|changed or force_reboot
+    changed_when: True

--- a/site.yml
+++ b/site.yml
@@ -22,3 +22,4 @@
     - web
     - database
     - DavidWittman.redis
+    - reboot-if-required


### PR DESCRIPTION
Add reboot if required. Inspired by https://github.com/amarao/ansible-reboot-if-needed-for-upgrade, taken over to have the ability to change execution order and add in Slack notifications.
